### PR TITLE
Add Kansas City Area Transportation Authority feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,19 @@ Or, feel free to [contact us](#contact) for assistance.
 
 Before opening pull requests, please validate your edits. You'll need Ruby 2.0 or later installed to run these scripts:
 
+Change the directory to the validator folder:
+
 ````
-cd validate
+cd validator
+````
+
+Get bundler if not installed:
+
+````
+gem install bundler
+````
+
+````
 bundle install
 bundle exec rake validate
 ````

--- a/feeds/f-9yu-kcata.json
+++ b/feeds/f-9yu-kcata.json
@@ -1,6 +1,6 @@
 {
     "feedFormat": "gtfs",
-    "onestopId": "f-9yu-unknown",
+    "onestopId": "f-9yu-kcata",
     "operatorsInFeed": [
         {
             "gtfsAgencyId": null,

--- a/feeds/f-9yu-unknown.json
+++ b/feeds/f-9yu-unknown.json
@@ -1,0 +1,17 @@
+{
+    "feedFormat": "gtfs",
+    "onestopId": "f-9yu-unknown",
+    "operatorsInFeed": [
+        {
+            "gtfsAgencyId": null,
+            "onestopId": "o-9yu-kcata",
+            "identifiers": [
+              "usntd://7005"
+            ]           
+        }
+    ],
+    "tags": {
+      "licenseUrl": "http://www.kcata.org/transit_data"
+    },
+    "url": "http://www.kc-metro.com/gtf/google_transit.zip"
+}


### PR DESCRIPTION
Added KCATA feed and updated the Readme.  The Transitland Python Client would not create a Onestop ID or feed file with the --feedname I set.  It would use "unknown", I renamed these with "kcata".  I have also added an issue to the client.

https://github.com/transitland/transitland-python-client/issues/26
